### PR TITLE
Made method getVariantList() to be virtual

### DIFF
--- a/src/models/abstractjsonrestlistmodel.h
+++ b/src/models/abstractjsonrestlistmodel.h
@@ -11,10 +11,11 @@ class AbstractJsonRestListModel : public BaseRestListModel
 public:
     explicit AbstractJsonRestListModel(QObject *parent = 0);
 
-private:
+protected:
     //for get list
-    QVariantList getVariantList(QByteArray bytes);
+    virtual QVariantList getVariantList(QByteArray bytes);
 
+private:
     //for get details for one element
     QVariantMap getVariantMap(QByteArray bytes);
 };

--- a/src/models/abstractxmlrestlistmodel.h
+++ b/src/models/abstractxmlrestlistmodel.h
@@ -47,10 +47,11 @@ signals:
     void rootElementChanged(QString rootElement);
     void itemElementChanged(QString itemElement);
 
-private:
+protected:
     //for get list
-    QVariantList getVariantList(QByteArray bytes);
+    virtual QVariantList getVariantList(QByteArray bytes);
 
+private:
     //for get details for one element
     QVariantMap getVariantMap(QByteArray bytes);
     QString m_rootElement;


### PR DESCRIPTION
Make method getVariantList to be virtual. I need to override method this to use this library on my service:

On request "/units.json" my service returns an object with property "units" where is the array of units. So I have to override getVariantList method to get "units" list.