### PR TITLE
Fix some warnings reported by GCC

### DIFF
--- a/src/apibase.cpp
+++ b/src/apibase.cpp
@@ -2,7 +2,7 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 
-APIBase::APIBase(QObject *parent) : QObject(parent), m_authTokenHeader("Authorization"), m_acceptHeader("Accept")
+APIBase::APIBase(QObject *parent) : QObject(parent), m_acceptHeader("Accept"), m_authTokenHeader("Authorization")
 {
     manager = new QNetworkAccessManager(this);
 

--- a/src/models/abstractxmlrestlistmodel.cpp
+++ b/src/models/abstractxmlrestlistmodel.cpp
@@ -110,7 +110,6 @@ QVariantMap AbstractXmlRestListModel::getVariantMap(QByteArray bytes)
     QVariantMap map;
 
     bool isInRoot = false;
-    int itemStartCount = 0;
     QString currentElementName;
     while (!xml.atEnd() && !xml.hasError())
     {

--- a/src/models/baserestlistmodel.cpp
+++ b/src/models/baserestlistmodel.cpp
@@ -1,8 +1,8 @@
 #include "baserestlistmodel.h"
 #include <QtQml>
 
-BaseRestListModel::BaseRestListModel(QObject *parent) : QAbstractListModel(parent), m_sort("-id"),
-    m_roleNamesIndex(0), m_loadingStatus(LoadingStatus::Idle), m_detailRoleNamesGenerated(false), m_apiInstance(nullptr)
+BaseRestListModel::BaseRestListModel(QObject *parent) : QAbstractListModel(parent), m_roleNamesIndex(0),
+    m_detailRoleNamesGenerated(false), m_sort("-id"), m_loadingStatus(LoadingStatus::Idle), m_apiInstance(nullptr)
 {
 
 }
@@ -155,6 +155,12 @@ void BaseRestListModel::fetchDetail(QString id)
 {
     m_fetchDetailLastId = id;
     RestItem item = findItemById(id);
+
+    if (!item.isValid()) {
+        qWarning() << QString("No item with id %1").arg(id);
+        return;
+    }
+
     if (item.isUpdated()) {
         return;
     }
@@ -251,11 +257,20 @@ RestItem BaseRestListModel::findItemById(QString id)
             return item;
         }
     }
+
+    return RestItem();
 }
 
 void BaseRestListModel::updateItem(QVariantMap value)
 {
-    RestItem item = findItemById(fetchDetailLastId());
+    QString id = fetchDetailLastId();
+    RestItem item = findItemById(id);
+
+    if (!item.isValid()) {
+        qWarning() << QString("No item with id %1").arg(id);
+        return;
+    }
+
     int row = m_items.indexOf(item);
     item.update(value);
     m_items.replace(row, item);

--- a/src/models/pagination.cpp
+++ b/src/models/pagination.cpp
@@ -1,8 +1,8 @@
 #include "pagination.h"
 
 Pagination::Pagination(QObject *parent) : QObject(parent),
-    m_perPage(20), m_currentPage(0), m_totalCount(0), m_pageCount(0),
-    m_currentPageHeader("X-Pagination-Current-Page"), m_totalCountHeader("X-Pagination-Total-Count"), m_pageCountHeader("X-Pagination-Page-Count")
+    m_perPage(20), m_currentPage(0), m_currentPageHeader("X-Pagination-Current-Page"), m_totalCount(0),
+    m_totalCountHeader("X-Pagination-Total-Count"), m_pageCount(0), m_pageCountHeader("X-Pagination-Page-Count")
 {
 
 }

--- a/src/models/restitem.cpp
+++ b/src/models/restitem.cpp
@@ -1,10 +1,14 @@
 #include "restitem.h"
 #include <QDebug>
 
+RestItem::RestItem() : m_isUpdated(false), m_isValid(false) {
+}
+
 RestItem::RestItem(QVariantMap object, QString idField) {
     m_object = object;
     m_idField = idField;
     m_isUpdated = false;
+    m_isValid = true;
 }
 
 QVariant RestItem::value(QString key) {
@@ -21,6 +25,11 @@ QString RestItem::id() const {
 
 bool RestItem::isUpdated() {
     return m_isUpdated;
+}
+
+bool RestItem::isValid() const
+{
+    return m_isValid;
 }
 
 void RestItem::update(QVariantMap value) {

--- a/src/models/restitem.h
+++ b/src/models/restitem.h
@@ -5,11 +5,13 @@
 
 class RestItem {
 public:
+    RestItem();
     explicit RestItem(QVariantMap object, QString idField);
     QVariant value(QString key);
     QStringList keys();
     QString id() const;
     bool isUpdated();
+    bool isValid() const;
 
     void update (QVariantMap value);
 
@@ -18,6 +20,7 @@ private:
     QVariantMap m_object;
     QString m_idField;
     bool m_isUpdated;
+    bool m_isValid;
 };
 
 #endif // RESTITEM_H


### PR DESCRIPTION
This fixes the following 6 warnings:

Warnings 1:

```text
In file included from api/qtrest/src/apibase.cpp:1:0:
api/qtrest/src/apibase.h: In constructor ‘APIBase::APIBase(QObject*)’:
api/qtrest/src/apibase.h:91:16: warning: ‘APIBase::m_authTokenHeader’ will be initialized after [-Wreorder]
     QByteArray m_authTokenHeader;
                ^
api/qtrest/src/apibase.h:89:16: warning:   ‘QByteArray APIBase::m_acceptHeader’ [-Wreorder]
     QByteArray m_acceptHeader;
                ^
api/qtrest/src/apibase.cpp:5:1: warning:   when initialized here [-Wreorder]
 APIBase::APIBase(QObject *parent) : QObject(parent), m_authTokenHeader("Authorization"), m_acceptHeader("Accept")
 ^
```

Warning 2:

```text
In file included from api/qtrest/src/models/baserestlistmodel.cpp:1:0:
api/qtrest/src/models/baserestlistmodel.h: In constructor ‘BaseRestListModel::BaseRestListModel(QObject*)’:
api/qtrest/src/models/baserestlistmodel.h:165:17: warning: ‘BaseRestListModel::m_sort’ will be initialized after [-Wreorder]
     QStringList m_sort;
                 ^
api/qtrest/src/models/baserestlistmodel.h:160:9: warning:   ‘int BaseRestListModel::m_roleNamesIndex’ [-Wreorder]
     int m_roleNamesIndex;
         ^
api/qtrest/src/models/baserestlistmodel.cpp:4:1: warning:   when initialized here [-Wreorder]
 BaseRestListModel::BaseRestListModel(QObject *parent) : QAbstractListModel(parent), m_sort("-id"),
 ^
```

Warning 3:

```text
In file included from api/qtrest/src/models/baserestlistmodel.cpp:1:0:
api/qtrest/src/models/baserestlistmodel.h:166:19: warning: ‘BaseRestListModel::m_loadingStatus’ will be initialized after [-Wreorder]
     LoadingStatus m_loadingStatus;
                   ^
api/qtrest/src/models/baserestlistmodel.h:161:10: warning:   ‘bool BaseRestListModel::m_detailRoleNamesGenerated’ [-Wreorder]
     bool m_detailRoleNamesGenerated;
          ^
api/qtrest/src/models/baserestlistmodel.cpp:4:1: warning:   when initialized here [-Wreorder]
 BaseRestListModel::BaseRestListModel(QObject *parent) : QAbstractListModel(parent), m_sort("-id"),
 ^
```

Warning 4:

```text
api/qtrest/src/models/baserestlistmodel.cpp: In member function ‘RestItem BaseRestListModel::findItemById(QString)’:
api/qtrest/src/models/baserestlistmodel.cpp:254:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
```

Warning 5:

```text
In file included from api/qtrest/src/models/pagination.cpp:1:0:
api/qtrest/src/models/pagination.h: In constructor ‘Pagination::Pagination(QObject*)’:
api/qtrest/src/models/pagination.h:105:9: warning: ‘Pagination::m_pageCount’ will be initialized after [-Wreorder]
     int m_pageCount;
         ^
api/qtrest/src/models/pagination.h:102:13: warning:   ‘QString Pagination::m_currentPageHeader’ [-Wreorder]
     QString m_currentPageHeader;
             ^
api/qtrest/src/models/pagination.cpp:3:1: warning:   when initialized here [-Wreorder]
 Pagination::Pagination(QObject *parent) : QObject(parent),
 ^
```

Warning 6:

```text
api/qtrest/src/models/abstractxmlrestlistmodel.cpp: In member function ‘virtual QVariantMap AbstractXmlRestListModel::getVariantMap(QByteArray)’:
api/qtrest/src/models/abstractxmlrestlistmodel.cpp:113:9: warning: unused variable ‘itemStartCount’ [-Wunused-variable]
     int itemStartCount = 0;
         ^
```

They were all trivial except for number 4, where I had to add the concept of a "null" `RestItem`, so that `findItemById` could return that when the item wasn't found.